### PR TITLE
Accept anything in the range 200-299 as OK. Follow redirects.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,14 @@
+A simple Falcon API that returns random response codes.
+
+Simply install `falcon` and `gunicorn` and start the API:
+
+```
+gunicorn --bind 0.0.0.0:8000 testapi:api
+```
+
+Now whenever you access http://localhost:8000, a random response code will be generated:
+
+```
+$ curl -w %{http_code} http://localhost:8000
+400
+```

--- a/test/testapi.py
+++ b/test/testapi.py
@@ -1,0 +1,12 @@
+import falcon
+import random
+
+class random_response():
+    def on_get(self,req,resp):
+        codes = [200,201,202,203,301,302,400,401,403,404,500,501,503]
+        random_code = random.choice(codes)
+        resp.status=getattr(falcon,"HTTP_%d" % random_code)
+
+api = falcon.API()
+random_route = random_response()
+api.add_route('/', random_route)

--- a/test/testapi.py
+++ b/test/testapi.py
@@ -1,12 +1,11 @@
 import falcon
 import random
 
-class random_response():
+class RandomResponse():
     def on_get(self,req,resp):
         codes = [200,201,202,203,301,302,400,401,403,404,500,501,503]
         random_code = random.choice(codes)
         resp.status=getattr(falcon,"HTTP_%d" % random_code)
 
 api = falcon.API()
-random_route = random_response()
-api.add_route('/', random_route)
+api.add_route('/', RandomResponse())


### PR DESCRIPTION
400/500 series codes are errors.

I tested this against http://httpstat.us, tossing a few different codes at it, and it works. It might be worth building a basic script that spits back random HTTP status codes to ensure that the test harness gathers the right metrics.